### PR TITLE
[navoutformat.cpp] CodecID -> AVCodecID

### DIFF
--- a/src/navoutformat.cpp
+++ b/src/navoutformat.cpp
@@ -235,7 +235,7 @@ Handle<Value> NAVOutputFormat::AddStream(const Arguments& args) {
   Local<Object> self = args.This();
   
   AVMediaType codec_type;
-  CodecID codec_id;
+  AVCodecID codec_id;
   
   NAVOutputFormat* instance = UNWRAP_OBJECT(NAVOutputFormat, args);
   
@@ -266,7 +266,7 @@ Handle<Value> NAVOutputFormat::AddStream(const Arguments& args) {
     codec_id = instance->pOutputFormat->audio_codec;
   }
   
-  codec_id = (CodecID) GET_OPTION_UINT32(options, codec, codec_id);
+  codec_id = (AVCodecID) GET_OPTION_UINT32(options, codec, codec_id);
   
   AVCodec* pCodec = avcodec_find_encoder(codec_id);
   if (!pCodec) {


### PR DESCRIPTION
This allows me to compile navcodec on Debian with libavformat 2.1.1 (from the deb-multimedia.org set of packages).

It's been called AVCodec for a while (libav/libav@2ff67c909c95903240c30405b0b231ba68f5407a, libav/libav@36ef5369ee9b336febc2c270f8718cec4476cb85). There was a backwards compatible #define, but that got removed in libav commit libav/libav@bdd1567c355a8092e7746ef99e831d579e34fa6a.

-David
