### PR TITLE
Enable building on windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -50,6 +50,18 @@
               "-lavresample",
               "-lavutil"
           ]
+        }],
+        ['OS=="win"', {
+            "include_dirs": [
+                "$(LIBAV_PATH)include"
+                ],
+            "libraries" : [
+                  "-l$(LIBAV_PATH)avcodec",
+                  "-l$(LIBAV_PATH)avformat",
+                  "-l$(LIBAV_PATH)swscale",
+                  "-l$(LIBAV_PATH)avresample",
+                  "-l$(LIBAV_PATH)avutil"
+                ]
         }]
       ],
 	  }

--- a/src/relocatemoov.cpp
+++ b/src/relocatemoov.cpp
@@ -36,6 +36,9 @@
 #ifdef __MINGW32__
 #define fseeko(x, y, z) fseeko64(x, y, z)
 #define ftello(x)       ftello64(x)
+#elif defined(_WIN32)
+#define fseeko(x, y, z) _fseeki64(x, y, z)
+#define ftello(x)       _ftelli64(x)
 #endif
 
 #define BE_16(x) ((((uint8_t*)(x))[0] <<  8) | ((uint8_t*)(x))[1])


### PR DESCRIPTION
Hi,

I have compiled libav using Visual Studio (because node-gyp cannot handle MinGW) and been able to link navcodec to it. Only these small changes were required.

I haven't deployed this code yet, that will happen next week, however as it stands I think these two commits are worth merging.

Regards
Phil